### PR TITLE
add optional `else` arg to `if()`

### DIFF
--- a/src/builtins.js
+++ b/src/builtins.js
@@ -29,6 +29,9 @@ export function makeBuiltins() {
   variables['if'] = new lib.Variable(new lib.LFunction(function(args) {
     if (lib.toJBoolean(args[0])) {
       lib.call(args[1], []);
+    } else {
+      // optional `else`
+      if(args[2]) lib.call(args[2], []);
     }
   }));
 


### PR DESCRIPTION
```
# `if` can now take an `else` callback - just like `ifel` #
if(true, fn() {
    print("Called for true");
}, fn() {
    print("Called for false");
});
```
