### PR TITLE
String escapes

### DIFF
--- a/dist/grammar.js
+++ b/dist/grammar.js
@@ -105,17 +105,19 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
         return [d[0]].concat(d[1]);
       } }, { "name": "StringExpressionDoubleContents", "symbols": ["StringExpressionDoubleContents$ebnf$1"], "postprocess": function postprocess(d) {
         return d[0].join('');
-      } }, { "name": "DoubleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": function postprocess(data, location, reject) {
+      } }, { "name": "DoubleStringValidCharacter", "symbols": ["EscapeCode"] }, { "name": "DoubleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": function postprocess(data, location, reject) {
         if (data[0][0] === '"') return reject;else return data[0][0];
       }
     }, { "name": "StringExpressionSingleContents$ebnf$1", "symbols": [] }, { "name": "StringExpressionSingleContents$ebnf$1", "symbols": ["SingleStringValidCharacter", "StringExpressionSingleContents$ebnf$1"], "postprocess": function arrconcat(d) {
         return [d[0]].concat(d[1]);
       } }, { "name": "StringExpressionSingleContents", "symbols": ["StringExpressionSingleContents$ebnf$1"], "postprocess": function postprocess(d) {
         return d[0].join('');
-      } }, { "name": "SingleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": function postprocess(data, location, reject) {
+      } }, { "name": "SingleStringValidCharacter", "symbols": ["EscapeCode"] }, { "name": "SingleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": function postprocess(data, location, reject) {
         if (data[0][0] === '\'') return reject;else return data[0][0];
       }
-    }, { "name": "NumberExpression", "symbols": ["_Number"], "postprocess": function postprocess(d) {
+    }, { "name": "EscapeCode$subexpression$1", "symbols": [/./] }, { "name": "EscapeCode$subexpression$1", "symbols": [{ "literal": "\n" }] }, { "name": "EscapeCode", "symbols": [{ "literal": "\\" }, "EscapeCode$subexpression$1"], "postprocess": function postprocess(d) {
+        return d[1][0];
+      } }, { "name": "NumberExpression", "symbols": ["_Number"], "postprocess": function postprocess(d) {
         return [C.NUMBER_PRIM, d[0]];
       } }, { "name": "_Number$ebnf$1", "symbols": [{ "literal": "-" }], "postprocess": id }, { "name": "_Number$ebnf$1", "symbols": [], "postprocess": function postprocess(d) {
         return null;
@@ -151,11 +153,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
         }
         return reject;
       }
-    }, { "name": "GenericValidIdentifierCharacter", "symbols": ["GenericValidCharacter"], "postprocess": function postprocess(data, location, reject) {
+    }, { "name": "GenericValidIdentifierCharacter", "symbols": [/./], "postprocess": function postprocess(data, location, reject) {
         //console.log(data[0], location)
         return data[0] && C.SPECIAL_CHARS.indexOf(data[0]) === -1 ? data[0] : reject;
       }
-    }, { "name": "GenericValidCharacter", "symbols": [/./] }, { "name": "Comment$ebnf$1", "symbols": [] }, { "name": "Comment$ebnf$1", "symbols": [/[^#]/, "Comment$ebnf$1"], "postprocess": function arrconcat(d) {
+    }, { "name": "GenericValidCharacter", "symbols": [/./], "postprocess": function postprocess(data, location, reject) {
+        return data[0] === '\\' ? reject : data;
+      }
+    }, { "name": "Comment$ebnf$1", "symbols": [] }, { "name": "Comment$ebnf$1", "symbols": [/[^#]/, "Comment$ebnf$1"], "postprocess": function arrconcat(d) {
         return [d[0]].concat(d[1]);
       } }, { "name": "Comment", "symbols": [{ "literal": "#" }, "Comment$ebnf$1", { "literal": "#" }], "postprocess": function postprocess(d) {
         return [C.COMMENT];

--- a/dist/grammar.ne
+++ b/dist/grammar.ne
@@ -120,19 +120,21 @@ StringExpression -> _StringExpression {% function(d) { return [C.STRING_PRIM, d[
 _StringExpression -> "\"" StringExpressionDoubleContents "\""
                    | "'" StringExpressionSingleContents "'"
 StringExpressionDoubleContents -> DoubleStringValidCharacter:* {% function(d) { return d[0].join('') } %}
-DoubleStringValidCharacter -> GenericValidCharacter {%
+DoubleStringValidCharacter -> EscapeCode | GenericValidCharacter {%
   function(data, location, reject) {
     if (data[0][0] === '"') return reject;
     else return data[0][0];
   }
 %}
 StringExpressionSingleContents -> SingleStringValidCharacter:* {% function(d) { return d[0].join('') } %}
-SingleStringValidCharacter -> GenericValidCharacter {%
+SingleStringValidCharacter -> EscapeCode | GenericValidCharacter {%
   function(data, location, reject) {
     if (data[0][0] === '\'') return reject;
     else return data[0][0];
   }
 %}
+
+EscapeCode -> "\\" (. | "\n") {% function(d) { return d[1][0]; } %}
 
 # Number expression
 NumberExpression -> _Number {% function(d) { return [C.NUMBER_PRIM, d[0]] } %}
@@ -166,13 +168,17 @@ Identifier -> GenericValidIdentifierCharacter:+ {%
     return reject;
   }
 %}
-GenericValidIdentifierCharacter -> GenericValidCharacter {%
+GenericValidIdentifierCharacter -> . {%
   function(data, location, reject) {
     //console.log(data[0], location)
     return data[0] && C.SPECIAL_CHARS.indexOf(data[0]) === -1 ? data[0] : reject;
   }
 %}
 
-GenericValidCharacter -> .
+GenericValidCharacter -> . {%
+  function(data, location, reject) {
+    return data[0] === '\\' ? reject : data
+  }
+%}
 
 Comment -> "#" [^#]:* "#" {% function(d) { return [C.COMMENT] } %}

--- a/dist/tests.js
+++ b/dist/tests.js
@@ -15,17 +15,21 @@ var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 var _templateObject = (0, _taggedTemplateLiteral3.default)(['hello!'], ['hello!']),
     _templateObject2 = (0, _taggedTemplateLiteral3.default)(['single quoted'], ['single quoted']),
     _templateObject3 = (0, _taggedTemplateLiteral3.default)(['foobar'], ['foobar']),
-    _templateObject4 = (0, _taggedTemplateLiteral3.default)(['7'], ['7']),
-    _templateObject5 = (0, _taggedTemplateLiteral3.default)(['-1'], ['-1']),
-    _templateObject6 = (0, _taggedTemplateLiteral3.default)(['12'], ['12']),
-    _templateObject7 = (0, _taggedTemplateLiteral3.default)(['0.75'], ['0.75']),
-    _templateObject8 = (0, _taggedTemplateLiteral3.default)(['3.005'], ['3.005']),
-    _templateObject9 = (0, _taggedTemplateLiteral3.default)(['good'], ['good']),
-    _templateObject10 = (0, _taggedTemplateLiteral3.default)(['false'], ['false']),
-    _templateObject11 = (0, _taggedTemplateLiteral3.default)(['true'], ['true']),
-    _templateObject12 = (0, _taggedTemplateLiteral3.default)(['100'], ['100']),
-    _templateObject13 = (0, _taggedTemplateLiteral3.default)(['0'], ['0']),
-    _templateObject14 = (0, _taggedTemplateLiteral3.default)(['thisisawesome'], ['thisisawesome']);
+    _templateObject4 = (0, _taggedTemplateLiteral3.default)(['single quoted \'escape'], ['single quoted \'escape']),
+    _templateObject5 = (0, _taggedTemplateLiteral3.default)(['double quoted "escape'], ['double quoted "escape']),
+    _templateObject6 = (0, _taggedTemplateLiteral3.default)(['newline\nescape'], ['newline\\nescape']),
+    _templateObject7 = (0, _taggedTemplateLiteral3.default)(['escape \\escape'], ['escape \\\\escape']),
+    _templateObject8 = (0, _taggedTemplateLiteral3.default)(['7'], ['7']),
+    _templateObject9 = (0, _taggedTemplateLiteral3.default)(['-1'], ['-1']),
+    _templateObject10 = (0, _taggedTemplateLiteral3.default)(['12'], ['12']),
+    _templateObject11 = (0, _taggedTemplateLiteral3.default)(['0.75'], ['0.75']),
+    _templateObject12 = (0, _taggedTemplateLiteral3.default)(['3.005'], ['3.005']),
+    _templateObject13 = (0, _taggedTemplateLiteral3.default)(['good'], ['good']),
+    _templateObject14 = (0, _taggedTemplateLiteral3.default)(['false'], ['false']),
+    _templateObject15 = (0, _taggedTemplateLiteral3.default)(['true'], ['true']),
+    _templateObject16 = (0, _taggedTemplateLiteral3.default)(['100'], ['100']),
+    _templateObject17 = (0, _taggedTemplateLiteral3.default)(['0'], ['0']),
+    _templateObject18 = (0, _taggedTemplateLiteral3.default)(['thisisawesome'], ['thisisawesome']);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -105,139 +109,157 @@ console.time('Total tests time');
 
         case 10:
 
-          console.log('Math ---');
-          // Test basic math operator functions
+          console.log('Escape codes ---');
           _context.next = 13;
-          return test('print(+(3, 4));', checkOut(_templateObject4));
+          return test('print(\'single quoted \\\'escape\');', checkOut(_templateObject4));
 
         case 13:
           _context.next = 15;
-          return test('print(-(3, 4));', checkOut(_templateObject5));
+          return test('print("double quoted \\"escape");', checkOut(_templateObject5));
 
         case 15:
           _context.next = 17;
-          return test('print(*(3, 4));', checkOut(_templateObject6));
+          return test('print(\'newline\\\nescape\');', checkOut(_templateObject6));
 
         case 17:
           _context.next = 19;
-          return test('print(/(3, 4));', checkOut(_templateObject7));
+          return test('print(\'escape \\\\escape\');', checkOut(_templateObject7));
 
         case 19:
-          _context.next = 21;
-          return test('print(+(1.25, 1.755));', checkOut(_templateObject8));
 
-        case 21:
+          console.log('Math ---');
+          // Test basic math operator functions
+          _context.next = 22;
+          return test('print(+(3, 4));', checkOut(_templateObject8));
 
-          console.log('If/else ---');
-          // Test basic if
+        case 22:
           _context.next = 24;
-          return test('\n    if(true, {\n      print("good");\n    });', checkOut(_templateObject9));
+          return test('print(-(3, 4));', checkOut(_templateObject9));
 
         case 24:
           _context.next = 26;
-          return test('\n    ifel(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject9));
+          return test('print(*(3, 4));', checkOut(_templateObject10));
 
         case 26:
           _context.next = 28;
-          return test('\n    if(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject9));
+          return test('print(/(3, 4));', checkOut(_templateObject11));
 
         case 28:
+          _context.next = 30;
+          return test('print(+(1.25, 1.755));', checkOut(_templateObject12));
 
-          console.log('Logic and comparison ---');
-          // Test logic operator functions
-          _context.next = 31;
-          return test('print(and(true, false));', checkOut(_templateObject10));
+        case 30:
 
-        case 31:
+          console.log('If/else ---');
+          // Test basic if
           _context.next = 33;
-          return test('print(or(true, false));', checkOut(_templateObject11));
+          return test('\n    if(true, {\n      print("good");\n    });', checkOut(_templateObject13));
 
         case 33:
           _context.next = 35;
-          return test('print(not(true));', checkOut(_templateObject10));
+          return test('\n    ifel(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject13));
 
         case 35:
           _context.next = 37;
-          return test('print(not(false));', checkOut(_templateObject11));
+          return test('\n    if(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject13));
 
         case 37:
-          _context.next = 39;
-          return test('print(eq(10, 20));', checkOut(_templateObject10));
 
-        case 39:
-          _context.next = 41;
-          return test('print(eq(45, 45));', checkOut(_templateObject11));
+          console.log('Logic and comparison ---');
+          // Test logic operator functions
+          _context.next = 40;
+          return test('print(and(true, false));', checkOut(_templateObject14));
 
-        case 41:
-          _context.next = 43;
-          return test('print(lt(10, 20));', checkOut(_templateObject11));
+        case 40:
+          _context.next = 42;
+          return test('print(or(true, false));', checkOut(_templateObject15));
 
-        case 43:
-          _context.next = 45;
-          return test('print(lt(70, 30));', checkOut(_templateObject10));
+        case 42:
+          _context.next = 44;
+          return test('print(not(true));', checkOut(_templateObject14));
 
-        case 45:
-          _context.next = 47;
-          return test('print(lt(45, 45));', checkOut(_templateObject10));
+        case 44:
+          _context.next = 46;
+          return test('print(not(false));', checkOut(_templateObject15));
 
-        case 47:
-          _context.next = 49;
-          return test('print(gt(10, 20));', checkOut(_templateObject10));
+        case 46:
+          _context.next = 48;
+          return test('print(eq(10, 20));', checkOut(_templateObject14));
 
-        case 49:
-          _context.next = 51;
-          return test('print(gt(70, 30));', checkOut(_templateObject11));
+        case 48:
+          _context.next = 50;
+          return test('print(eq(45, 45));', checkOut(_templateObject15));
 
-        case 51:
-          _context.next = 53;
-          return test('print(gt(45, 45));', checkOut(_templateObject10));
+        case 50:
+          _context.next = 52;
+          return test('print(lt(10, 20));', checkOut(_templateObject15));
 
-        case 53:
+        case 52:
+          _context.next = 54;
+          return test('print(lt(70, 30));', checkOut(_templateObject14));
 
-          console.log('Surround functions ---');
+        case 54:
           _context.next = 56;
-          return test('print((true and false))', checkOut(_templateObject10));
+          return test('print(lt(45, 45));', checkOut(_templateObject14));
 
         case 56:
           _context.next = 58;
-          return test('print((true & true))', checkOut(_templateObject11));
+          return test('print(gt(10, 20));', checkOut(_templateObject14));
 
         case 58:
           _context.next = 60;
-          return test('print((99 + 1))', checkOut(_templateObject12));
+          return test('print(gt(70, 30));', checkOut(_templateObject15));
 
         case 60:
           _context.next = 62;
-          return test('print((20 > 1))', checkOut(_templateObject11));
+          return test('print(gt(45, 45));', checkOut(_templateObject14));
 
         case 62:
-          _context.next = 64;
-          return test('print((1 - 1))', checkOut(_templateObject13));
 
-        case 64:
-          _context.next = 66;
-          return test('print((\'this\' concat \'is\' \'awesome\'))', checkOut(_templateObject14));
+          console.log('Surround functions ---');
+          _context.next = 65;
+          return test('print((true and false))', checkOut(_templateObject14));
 
-        case 66:
+        case 65:
+          _context.next = 67;
+          return test('print((true & true))', checkOut(_templateObject15));
+
+        case 67:
+          _context.next = 69;
+          return test('print((99 + 1))', checkOut(_templateObject16));
+
+        case 69:
+          _context.next = 71;
+          return test('print((20 > 1))', checkOut(_templateObject15));
+
+        case 71:
           _context.next = 73;
+          return test('print((1 - 1))', checkOut(_templateObject17));
+
+        case 73:
+          _context.next = 75;
+          return test('print((\'this\' concat \'is\' \'awesome\'))', checkOut(_templateObject18));
+
+        case 75:
+          _context.next = 82;
           break;
 
-        case 68:
-          _context.prev = 68;
+        case 77:
+          _context.prev = 77;
           _context.t0 = _context['catch'](0);
 
           console.log = oldLog;
           console.log('\x1b[31m[Errored!]\x1b[0m Error in JS:');
           console.error(_context.t0);
 
-        case 73:
+        case 82:
           console.timeEnd('Total tests time');
           console.log(chalk.bold(passed + '/' + tests + ' passed.'));
 
-        case 75:
+        case 84:
         case 'end':
           return _context.stop();
       }
     }
-  }, _callee, this, [[0, 68]]);
+  }, _callee, this, [[0, 77]]);
 }))();

--- a/dist/tests.js
+++ b/dist/tests.js
@@ -19,17 +19,18 @@ var _templateObject = (0, _taggedTemplateLiteral3.default)(['hello!'], ['hello!'
     _templateObject5 = (0, _taggedTemplateLiteral3.default)(['double quoted "escape'], ['double quoted "escape']),
     _templateObject6 = (0, _taggedTemplateLiteral3.default)(['newline\nescape'], ['newline\\nescape']),
     _templateObject7 = (0, _taggedTemplateLiteral3.default)(['escape \\escape'], ['escape \\\\escape']),
-    _templateObject8 = (0, _taggedTemplateLiteral3.default)(['7'], ['7']),
-    _templateObject9 = (0, _taggedTemplateLiteral3.default)(['-1'], ['-1']),
-    _templateObject10 = (0, _taggedTemplateLiteral3.default)(['12'], ['12']),
-    _templateObject11 = (0, _taggedTemplateLiteral3.default)(['0.75'], ['0.75']),
-    _templateObject12 = (0, _taggedTemplateLiteral3.default)(['3.005'], ['3.005']),
-    _templateObject13 = (0, _taggedTemplateLiteral3.default)(['good'], ['good']),
-    _templateObject14 = (0, _taggedTemplateLiteral3.default)(['false'], ['false']),
-    _templateObject15 = (0, _taggedTemplateLiteral3.default)(['true'], ['true']),
-    _templateObject16 = (0, _taggedTemplateLiteral3.default)(['100'], ['100']),
-    _templateObject17 = (0, _taggedTemplateLiteral3.default)(['0'], ['0']),
-    _templateObject18 = (0, _taggedTemplateLiteral3.default)(['thisisawesome'], ['thisisawesome']);
+    _templateObject8 = (0, _taggedTemplateLiteral3.default)(['\'single\' and "double"'], ['\'single\' and "double"']),
+    _templateObject9 = (0, _taggedTemplateLiteral3.default)(['7'], ['7']),
+    _templateObject10 = (0, _taggedTemplateLiteral3.default)(['-1'], ['-1']),
+    _templateObject11 = (0, _taggedTemplateLiteral3.default)(['12'], ['12']),
+    _templateObject12 = (0, _taggedTemplateLiteral3.default)(['0.75'], ['0.75']),
+    _templateObject13 = (0, _taggedTemplateLiteral3.default)(['3.005'], ['3.005']),
+    _templateObject14 = (0, _taggedTemplateLiteral3.default)(['good'], ['good']),
+    _templateObject15 = (0, _taggedTemplateLiteral3.default)(['false'], ['false']),
+    _templateObject16 = (0, _taggedTemplateLiteral3.default)(['true'], ['true']),
+    _templateObject17 = (0, _taggedTemplateLiteral3.default)(['100'], ['100']),
+    _templateObject18 = (0, _taggedTemplateLiteral3.default)(['0'], ['0']),
+    _templateObject19 = (0, _taggedTemplateLiteral3.default)(['thisisawesome'], ['thisisawesome']);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -126,140 +127,144 @@ console.time('Total tests time');
           return test('print(\'escape \\\\escape\');', checkOut(_templateObject7));
 
         case 19:
+          _context.next = 21;
+          return test('print(\'\\\'single\\\' and \\"double\\"\')', checkOut(_templateObject8));
+
+        case 21:
 
           console.log('Math ---');
           // Test basic math operator functions
-          _context.next = 22;
-          return test('print(+(3, 4));', checkOut(_templateObject8));
-
-        case 22:
           _context.next = 24;
-          return test('print(-(3, 4));', checkOut(_templateObject9));
+          return test('print(+(3, 4));', checkOut(_templateObject9));
 
         case 24:
           _context.next = 26;
-          return test('print(*(3, 4));', checkOut(_templateObject10));
+          return test('print(-(3, 4));', checkOut(_templateObject10));
 
         case 26:
           _context.next = 28;
-          return test('print(/(3, 4));', checkOut(_templateObject11));
+          return test('print(*(3, 4));', checkOut(_templateObject11));
 
         case 28:
           _context.next = 30;
-          return test('print(+(1.25, 1.755));', checkOut(_templateObject12));
+          return test('print(/(3, 4));', checkOut(_templateObject12));
 
         case 30:
+          _context.next = 32;
+          return test('print(+(1.25, 1.755));', checkOut(_templateObject13));
+
+        case 32:
 
           console.log('If/else ---');
           // Test basic if
-          _context.next = 33;
-          return test('\n    if(true, {\n      print("good");\n    });', checkOut(_templateObject13));
-
-        case 33:
           _context.next = 35;
-          return test('\n    ifel(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject13));
+          return test('\n    if(true, {\n      print("good");\n    });', checkOut(_templateObject14));
 
         case 35:
           _context.next = 37;
-          return test('\n    if(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject13));
+          return test('\n    ifel(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject14));
 
         case 37:
+          _context.next = 39;
+          return test('\n    if(false, {\n      print("bad");\n    }, {\n      print("good");\n    });', checkOut(_templateObject14));
+
+        case 39:
 
           console.log('Logic and comparison ---');
           // Test logic operator functions
-          _context.next = 40;
-          return test('print(and(true, false));', checkOut(_templateObject14));
-
-        case 40:
           _context.next = 42;
-          return test('print(or(true, false));', checkOut(_templateObject15));
+          return test('print(and(true, false));', checkOut(_templateObject15));
 
         case 42:
           _context.next = 44;
-          return test('print(not(true));', checkOut(_templateObject14));
+          return test('print(or(true, false));', checkOut(_templateObject16));
 
         case 44:
           _context.next = 46;
-          return test('print(not(false));', checkOut(_templateObject15));
+          return test('print(not(true));', checkOut(_templateObject15));
 
         case 46:
           _context.next = 48;
-          return test('print(eq(10, 20));', checkOut(_templateObject14));
+          return test('print(not(false));', checkOut(_templateObject16));
 
         case 48:
           _context.next = 50;
-          return test('print(eq(45, 45));', checkOut(_templateObject15));
+          return test('print(eq(10, 20));', checkOut(_templateObject15));
 
         case 50:
           _context.next = 52;
-          return test('print(lt(10, 20));', checkOut(_templateObject15));
+          return test('print(eq(45, 45));', checkOut(_templateObject16));
 
         case 52:
           _context.next = 54;
-          return test('print(lt(70, 30));', checkOut(_templateObject14));
+          return test('print(lt(10, 20));', checkOut(_templateObject16));
 
         case 54:
           _context.next = 56;
-          return test('print(lt(45, 45));', checkOut(_templateObject14));
+          return test('print(lt(70, 30));', checkOut(_templateObject15));
 
         case 56:
           _context.next = 58;
-          return test('print(gt(10, 20));', checkOut(_templateObject14));
+          return test('print(lt(45, 45));', checkOut(_templateObject15));
 
         case 58:
           _context.next = 60;
-          return test('print(gt(70, 30));', checkOut(_templateObject15));
+          return test('print(gt(10, 20));', checkOut(_templateObject15));
 
         case 60:
           _context.next = 62;
-          return test('print(gt(45, 45));', checkOut(_templateObject14));
+          return test('print(gt(70, 30));', checkOut(_templateObject16));
 
         case 62:
+          _context.next = 64;
+          return test('print(gt(45, 45));', checkOut(_templateObject15));
+
+        case 64:
 
           console.log('Surround functions ---');
-          _context.next = 65;
-          return test('print((true and false))', checkOut(_templateObject14));
-
-        case 65:
           _context.next = 67;
-          return test('print((true & true))', checkOut(_templateObject15));
+          return test('print((true and false))', checkOut(_templateObject15));
 
         case 67:
           _context.next = 69;
-          return test('print((99 + 1))', checkOut(_templateObject16));
+          return test('print((true & true))', checkOut(_templateObject16));
 
         case 69:
           _context.next = 71;
-          return test('print((20 > 1))', checkOut(_templateObject15));
+          return test('print((99 + 1))', checkOut(_templateObject17));
 
         case 71:
           _context.next = 73;
-          return test('print((1 - 1))', checkOut(_templateObject17));
+          return test('print((20 > 1))', checkOut(_templateObject16));
 
         case 73:
           _context.next = 75;
-          return test('print((\'this\' concat \'is\' \'awesome\'))', checkOut(_templateObject18));
+          return test('print((1 - 1))', checkOut(_templateObject18));
 
         case 75:
-          _context.next = 82;
-          break;
+          _context.next = 77;
+          return test('print((\'this\' concat \'is\' \'awesome\'))', checkOut(_templateObject19));
 
         case 77:
-          _context.prev = 77;
+          _context.next = 84;
+          break;
+
+        case 79:
+          _context.prev = 79;
           _context.t0 = _context['catch'](0);
 
           console.log = oldLog;
           console.log('\x1b[31m[Errored!]\x1b[0m Error in JS:');
           console.error(_context.t0);
 
-        case 82:
+        case 84:
           console.timeEnd('Total tests time');
           console.log(chalk.bold(passed + '/' + tests + ' passed.'));
 
-        case 84:
+        case 86:
         case 'end':
           return _context.stop();
       }
     }
-  }, _callee, this, [[0, 77]]);
+  }, _callee, this, [[0, 79]]);
 }))();

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -97,6 +97,7 @@ var grammar = {
     {"name": "StringExpressionDoubleContents$ebnf$1", "symbols": []},
     {"name": "StringExpressionDoubleContents$ebnf$1", "symbols": ["DoubleStringValidCharacter", "StringExpressionDoubleContents$ebnf$1"], "postprocess": function arrconcat(d) {return [d[0]].concat(d[1]);}},
     {"name": "StringExpressionDoubleContents", "symbols": ["StringExpressionDoubleContents$ebnf$1"], "postprocess": function(d) { return d[0].join('') }},
+    {"name": "DoubleStringValidCharacter", "symbols": ["EscapeCode"]},
     {"name": "DoubleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": 
         function(data, location, reject) {
           if (data[0][0] === '"') return reject;
@@ -106,12 +107,16 @@ var grammar = {
     {"name": "StringExpressionSingleContents$ebnf$1", "symbols": []},
     {"name": "StringExpressionSingleContents$ebnf$1", "symbols": ["SingleStringValidCharacter", "StringExpressionSingleContents$ebnf$1"], "postprocess": function arrconcat(d) {return [d[0]].concat(d[1]);}},
     {"name": "StringExpressionSingleContents", "symbols": ["StringExpressionSingleContents$ebnf$1"], "postprocess": function(d) { return d[0].join('') }},
+    {"name": "SingleStringValidCharacter", "symbols": ["EscapeCode"]},
     {"name": "SingleStringValidCharacter", "symbols": ["GenericValidCharacter"], "postprocess": 
         function(data, location, reject) {
           if (data[0][0] === '\'') return reject;
           else return data[0][0];
         }
         },
+    {"name": "EscapeCode$subexpression$1", "symbols": [/./]},
+    {"name": "EscapeCode$subexpression$1", "symbols": [{"literal":"\n"}]},
+    {"name": "EscapeCode", "symbols": [{"literal":"\\"}, "EscapeCode$subexpression$1"], "postprocess": function(d) { return d[1][0]; }},
     {"name": "NumberExpression", "symbols": ["_Number"], "postprocess": function(d) { return [C.NUMBER_PRIM, d[0]] }},
     {"name": "_Number$ebnf$1", "symbols": [{"literal":"-"}], "postprocess": id},
     {"name": "_Number$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
@@ -150,13 +155,17 @@ var grammar = {
           return reject;
         }
         },
-    {"name": "GenericValidIdentifierCharacter", "symbols": ["GenericValidCharacter"], "postprocess": 
+    {"name": "GenericValidIdentifierCharacter", "symbols": [/./], "postprocess": 
         function(data, location, reject) {
           //console.log(data[0], location)
           return data[0] && C.SPECIAL_CHARS.indexOf(data[0]) === -1 ? data[0] : reject;
         }
         },
-    {"name": "GenericValidCharacter", "symbols": [/./]},
+    {"name": "GenericValidCharacter", "symbols": [/./], "postprocess": 
+        function(data, location, reject) {
+          return data[0] === '\\' ? reject : data
+        }
+        },
     {"name": "Comment$ebnf$1", "symbols": []},
     {"name": "Comment$ebnf$1", "symbols": [/[^#]/, "Comment$ebnf$1"], "postprocess": function arrconcat(d) {return [d[0]].concat(d[1]);}},
     {"name": "Comment", "symbols": [{"literal":"#"}, "Comment$ebnf$1", {"literal":"#"}], "postprocess": function(d) { return [C.COMMENT] }}

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -120,19 +120,21 @@ StringExpression -> _StringExpression {% function(d) { return [C.STRING_PRIM, d[
 _StringExpression -> "\"" StringExpressionDoubleContents "\""
                    | "'" StringExpressionSingleContents "'"
 StringExpressionDoubleContents -> DoubleStringValidCharacter:* {% function(d) { return d[0].join('') } %}
-DoubleStringValidCharacter -> GenericValidCharacter {%
+DoubleStringValidCharacter -> EscapeCode | GenericValidCharacter {%
   function(data, location, reject) {
     if (data[0][0] === '"') return reject;
     else return data[0][0];
   }
 %}
 StringExpressionSingleContents -> SingleStringValidCharacter:* {% function(d) { return d[0].join('') } %}
-SingleStringValidCharacter -> GenericValidCharacter {%
+SingleStringValidCharacter -> EscapeCode | GenericValidCharacter {%
   function(data, location, reject) {
     if (data[0][0] === '\'') return reject;
     else return data[0][0];
   }
 %}
+
+EscapeCode -> "\\" (. | "\n") {% function(d) { return d[1][0]; } %}
 
 # Number expression
 NumberExpression -> _Number {% function(d) { return [C.NUMBER_PRIM, d[0]] } %}
@@ -166,13 +168,17 @@ Identifier -> GenericValidIdentifierCharacter:+ {%
     return reject;
   }
 %}
-GenericValidIdentifierCharacter -> GenericValidCharacter {%
+GenericValidIdentifierCharacter -> . {%
   function(data, location, reject) {
     //console.log(data[0], location)
     return data[0] && C.SPECIAL_CHARS.indexOf(data[0]) === -1 ? data[0] : reject;
   }
 %}
 
-GenericValidCharacter -> .
+GenericValidCharacter -> . {%
+  function(data, location, reject) {
+    return data[0] === '\\' ? reject : data
+  }
+%}
 
 Comment -> "#" [^#]:* "#" {% function(d) { return [C.COMMENT] } %}

--- a/src/tests.js
+++ b/src/tests.js
@@ -73,6 +73,12 @@ console.time('Total tests time');
     await test(`print('single quoted');`, checkOut`single quoted`)
     await test(`print(concat("foo", "bar"));`, checkOut`foobar`)
 
+    console.log('Escape codes ---')
+    await test(`print('single quoted \\'escape');`, checkOut`single quoted 'escape`)
+    await test(`print("double quoted \\"escape");`, checkOut`double quoted "escape`)
+    await test(`print('newline\\\nescape');`, checkOut`newline\nescape`)
+    await test(`print('escape \\\\escape');`, checkOut`escape \\escape`)
+
     console.log('Math ---')
     // Test basic math operator functions
     await test(`print(+(3, 4));`, checkOut`7`)

--- a/src/tests.js
+++ b/src/tests.js
@@ -78,6 +78,7 @@ console.time('Total tests time');
     await test(`print("double quoted \\"escape");`, checkOut`double quoted "escape`)
     await test(`print('newline\\\nescape');`, checkOut`newline\nescape`)
     await test(`print('escape \\\\escape');`, checkOut`escape \\escape`)
+    await test(`print('\\'single\\' and \\"double\\"')`, checkOut`'single' and "double"`)
 
     console.log('Math ---')
     // Test basic math operator functions

--- a/test.tul
+++ b/test.tul
@@ -1,28 +1,5 @@
-time => 300;
-t => time;
-
-test-fn => async {
-  ret => return;
-  print('B');
-  set-timeout({
-    print('C');
-    ret(42);
-  }, (time + 25));
-};
-
-should-return-normally => {
-  print('E');
-  return('F');
-};
-
-print('A');
-test-fn();
-print('D');
-returned => should-return-normally();
-print(returned);
-print('G');
-# foo
-baz
-bar #
-
-# test #
+print('Hello \'world!\'');
+print("Hello \"world!\"");
+print('Hello \\ there!');
+print('Hello\
+Newlines ftw');


### PR DESCRIPTION
Here are the self-descriptive tests:

```
> print('single quoted \'escape');
single quoted 'escape
> print("double quoted \"escape");
double quoted "escape
> print('newline\nescape');
newline
escape
> print('escape \\escape');
escape \escape
```

And here's the related grammar:

```
EscapeCode -> "\\" (. | "\n") {% function(d) { return d[1][0]; } %}
```
